### PR TITLE
[Fix] Missed trailing null character space in decoder codeChr

### DIFF
--- a/src/Component/Decoder.cpp
+++ b/src/Component/Decoder.cpp
@@ -825,7 +825,7 @@ void Decoder::decode(Store& store, Stack& coreStack) {
       Instruction::f64_reinterpret_i64(coreStack);
       break;
     default: {
-      char codeChr[2];
+      char codeChr[3];
       sprintf(codeChr, "%02x", ((std::uint32_t)bincode) & 0xff);
 #ifdef NDEBUG
       throw Exception(std::string("Unknown code: 0x") + codeChr, coreStack);


### PR DESCRIPTION
I missed the space for the trailing null character in Decoder.cpp:828.

The size in currently fixed to 3.