### PR TITLE
Fix variables typo & add unittest

### DIFF
--- a/src/lib/core/runtime/i32_and.c
+++ b/src/lib/core/runtime/i32_and.c
@@ -2,9 +2,9 @@
 
 int runtime_i32_and(Stack* stack){
     Value *value1 = NULL, *value2 = NULL;
-    stack->entries->pop(stack->entries, (void**)&val2);
-    stack->entries->pop(stack->entries, (void**)&val1);
-    stack->entries->push(stack->entries, new_i32Value(val1->value.i32 & val2->value.i32));
+    stack->entries->pop(stack->entries, (void**)&value2);
+    stack->entries->pop(stack->entries, (void**)&value1);
+    stack->entries->push(stack->entries, new_i32Value(value1->value.i32 & value2->value.i32));
     free(value1);
     free(value2);
     return 0;

--- a/test/unittests/lib/CMakeLists.txt
+++ b/test/unittests/lib/CMakeLists.txt
@@ -9,4 +9,5 @@ macro(add_lib_unittest unittest)
 endmacro(add_lib_unittest unittest)
 
 add_lib_unittest(runtime/i32_add_unittest)
+add_lib_unittest(runtime/i32_and_unittest)
 add_lib_unittest(runtime/i32_sub_unittest)

--- a/test/unittests/lib/runtime/i32_and_unittest.hpp
+++ b/test/unittests/lib/runtime/i32_and_unittest.hpp
@@ -1,0 +1,24 @@
+#include <skypat/skypat.h>
+
+#define _Bool bool
+extern "C"{
+    #include <core/Runtime.h>
+}
+#undef _Bool 
+
+SKYPAT_F(Runtime_i32_and, regular)
+{
+    // prepare 
+    Stack* stack = new_Stack();
+    Value *val1 = new_i32Value(5), *val2 = new_i32Value(3);
+    stack->entries->push(stack->entries, val1);
+    stack->entries->push(stack->entries, val2);
+
+    // run
+    runtime_i32_and(stack);
+
+    // check 
+    Value *check = NULL;
+    stack->entries->pop(stack->entries, (void**)&check);
+    EXPECT_EQ(check->value.i32, 1); 
+}


### PR DESCRIPTION
`val1`, `val2` seems to be typos.
Fix them into the name in declaration.

Also add its unittest.